### PR TITLE
Add serial SDK

### DIFF
--- a/script/download_js_sdk
+++ b/script/download_js_sdk
@@ -3,11 +3,14 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-SDK_VER=latest
+BLE_SDK_VER=latest
+BLE_DOWNLOAD_URL=`npm view improv-wifi-sdk@$BLE_SDK_VER dist.tarball`
 
-DOWNLOAD_URL=`npm view improv-wifi-sdk@$SDK_VER dist.tarball`
+SERIAL_SDK_VER=latest
+SERIAL_DOWNLOAD_URL=`npm view improv-wifi-serial-sdk@$SERIAL_SDK_VER dist.tarball`
 
-rm -rf dist/sdk-js
-mkdir -p dist/sdk-js
+rm -rf dist/sdk-js dist/sdk-serial-js
+mkdir -p dist/sdk-js dist/sdk-serial-js
 
-curl $DOWNLOAD_URL | tar zx -C dist/sdk-js --strip-components 3 package/dist/web
+curl $BLE_DOWNLOAD_URL | tar zx -C dist/sdk-js --strip-components 3 package/dist/web
+curl $SERIAL_DOWNLOAD_URL | tar zx -C dist/sdk-serial-js --strip-components 3 package/dist/web

--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -52,6 +52,7 @@ Improv Wi-Fi: Open standard for setting up Wi-Fi via Bluetooth LE and Serial
       content="https://www.improv-wifi.com/images/social.png"
     />
     <script type="module" src="/sdk-js/launch-button.js"></script>
+    <script type="module" src="/sdk-serial-js/serial-launch-button.js"></script>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
This adds the serial SDK to the improv homepage.

Marked as draft because it requires an update to the SDKs. Although the SDKs now register the used MWC components under their own prefix, `<mwc-textfield>` imports `<mwc-notched-outline>` which currently causes an error because it will end up being defined twice.

https://github.com/material-components/material-web/blob/987a534fe75555a1a6b0854f0f9b9f999d72b7d0/packages/textfield/mwc-textfield-base.ts#L326